### PR TITLE
feat(deps): move typescript to peerDependecies

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,13 @@ This project uses the same MAJOR version as Jest.
 using npm
 
 ```sh
-npm install --save-dev jest dts-jest
+npm install --save-dev dts-jest jest typescript
 ```
 
 using yarn
 
 ```sh
-yarn add --dev jest dts-jest
+yarn add --dev dts-jest jest typescript
 ```
 
 ## Usage

--- a/package.json
+++ b/package.json
@@ -28,8 +28,7 @@
   "dependencies": {
     "require-from-string": "^1.2.1",
     "ts-comment": "^1.0.1",
-    "tsconfig-extends": "^1.0.1",
-    "typescript": "^2.4.0"
+    "tsconfig-extends": "^1.0.1"
   },
   "devDependencies": {
     "@types/jest": "20.0.7",
@@ -41,10 +40,12 @@
     "tslint": "5.6.0",
     "tslint-config-ikatyang": "2.2.0",
     "tslint-config-prettier-ext": "1.5.0",
-    "tslint-plugin-prettier": "1.1.0"
+    "tslint-plugin-prettier": "1.1.0",
+    "typescript": "2.4.2"
   },
   "peerDependencies": {
-    "jest": "^20.0.4"
+    "jest": "^20.0.4",
+    "typescript": "^2.0.0"
   },
   "engines": {
     "node": ">= 4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2205,7 +2205,7 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-typescript@^2.4.0:
+typescript@2.4.2, typescript@^2.4.0:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.4.2.tgz#f8395f85d459276067c988aa41837a8f82870844"
 


### PR DESCRIPTION
With this PR, TypeScript now has to be installed manually so that you can choose which version to use.