### PR TITLE
fix: transpile real-environment code

### DIFF
--- a/fixtures/transform/commonjs.ts
+++ b/fixtures/transform/commonjs.ts
@@ -1,0 +1,4 @@
+import * as path from 'path';
+
+// @dts-jest
+path.basename('path/to/somewhere'); //=> 'somewhere'

--- a/src/__snapshots__/runtime.test.ts.snap
+++ b/src/__snapshots__/runtime.test.ts.snap
@@ -46,6 +46,20 @@ to be
 "
 `;
 
+exports[`#get_type_report() should return inference report on non-fail line with line info while transpiled 1`] = `
+"
+(<cwd>/fixtures/runtime/example.ts:0)
+
+Inferred
+
+  Math.min(3, 2, 1)
+
+to be
+
+  number
+"
+`;
+
 exports[`#get_type_report() should return inference report with description on non-fail line with description 1`] = `
 "
 description-pass
@@ -86,6 +100,24 @@ but throw
 
 exports[`#get_value_report() should return formatted value report for non-fail getter 1`] = `
 "
+description-value
+
+Evaluated
+
+  Math.max(1, 2, 3)
+
+to be
+
+  Object {
+    \\"example\\": \\"value\\",
+  }
+"
+`;
+
+exports[`#get_value_report() should return formatted value report for non-fail getter with line info while transpiled 1`] = `
+"
+(<cwd>/fixtures/runtime/example.ts:16)
+
 description-value
 
 Evaluated

--- a/src/__snapshots__/transform.test.ts.snap
+++ b/src/__snapshots__/transform.test.ts.snap
@@ -136,6 +136,15 @@ describe(\\"Object.assign({\\\\n        a: 1,\\\\n      }, {\\\\n        b: 2,\\
  });"
 `;
 
+exports[`should transform to commonjs if set 1`] = `
+"<create_setup_expression>;\\"use strict\\";
+exports.__esModule = true;
+var path = require(\\"path\\");
+// @dts-jest
+describe(\\"path.basename('path/to/somewhere')\\", function () { test(\\"(value) should equal to \\\\\\"somewhere\\\\\\"\\", function () { expect(path.basename('path/to/somewhere')).toEqual(\\"somewhere\\"); }); }); //=> 'somewhere'
+"
+`;
+
 exports[`should transform to fake environment for no-footers even if test_value = true 1`] = `
 "<create_setup_expression>;
 describe(\\"Math.max(1)\\", function () { test(\\"(type) should not throw error\\", function () { expect(function () { _dts_jest_runtime_.get_type_inference_or_throw_diagnostic(1) }).not.toThrowError() }) })

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -123,6 +123,7 @@ export interface RawConfig extends DocblockOptions {
   enclosing_declaration?: boolean;
   type_format_flags?: _ts.TypeFormatFlags;
   typescript?: string;
+  transpile?: boolean;
 }
 
 export interface NormalizedConfig {
@@ -133,4 +134,5 @@ export interface NormalizedConfig {
   type_format_flags: _ts.TypeFormatFlags;
   typescript: typeof _ts;
   typescript_path: string;
+  transpile: boolean;
 }

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -14,5 +14,5 @@ export const setup = (
   const normalized_config = normalize_config(raw_config, root_dir);
   const snapshots = create_snapshots(filename, triggers, normalized_config);
 
-  return new Runtime(triggers, snapshots);
+  return new Runtime(filename, normalized_config, triggers, snapshots);
 };

--- a/src/transform.test.ts
+++ b/src/transform.test.ts
@@ -48,6 +48,16 @@ it('should respect docblock options', () => {
   );
 });
 
+it('should transform to commonjs if set', () => {
+  expect(
+    transform_fixture('commonjs', {
+      test_value: true,
+      transpile: true,
+      compiler_options: { module: 'commonjs' },
+    }),
+  ).toMatchSnapshot();
+});
+
 function transform_fixture(
   id: string,
   raw_config: RawConfig,
@@ -58,7 +68,7 @@ function transform_fixture(
   const source = preprocessor(load_fixture(full_id));
   const config: JestConfig = {
     rootDir: '',
-    globals: { _dts_jest_: raw_config },
+    globals: { _dts_jest_: { transpile: false, ...raw_config } },
   };
   return transform(source, filename, config as any);
 }

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -98,6 +98,7 @@ export const transform: jest.Transformer['process'] = (
       fileName: source_filename,
     });
 
+    // istanbul ignore next
     if (
       transpile_output.diagnostics !== undefined &&
       transpile_output.diagnostics.length !== 0

--- a/src/utils/normalize-config.ts
+++ b/src/utils/normalize-config.ts
@@ -13,6 +13,7 @@ export const normalize_config = (
     compiler_options: raw_compiler_options = {},
     enclosing_declaration = false,
     typescript: typescript_id = 'typescript',
+    transpile = true,
   } = raw_config;
 
   const { typescript, typescript_path } = load_typescript(
@@ -34,6 +35,7 @@ export const normalize_config = (
   );
 
   return {
+    transpile,
     test_type,
     test_value,
     compiler_options,


### PR DESCRIPTION
Add option `transpile` (default: true) to determine if need transpile.

- if no need to transpile, would be better to disable this option
  - e.g. pure javascript (`node` compatible)
- `console.log` in transpiled code
  - line number from jest is not correct since no source map support
  - add custom line number for `:show` and `//=> ?` report