### PR TITLE
fix(runtime): show 1-based line number

### DIFF
--- a/src/__snapshots__/runtime.test.ts.snap
+++ b/src/__snapshots__/runtime.test.ts.snap
@@ -48,7 +48,7 @@ to be
 
 exports[`#get_type_report() should return inference report on non-fail line with line info while transpiled 1`] = `
 "
-(<cwd>/fixtures/runtime/example.ts:0)
+(<cwd>/fixtures/runtime/example.ts:2)
 
 Inferred
 
@@ -116,7 +116,7 @@ to be
 
 exports[`#get_value_report() should return formatted value report for non-fail getter with line info while transpiled 1`] = `
 "
-(<cwd>/fixtures/runtime/example.ts:16)
+(<cwd>/fixtures/runtime/example.ts:17)
 
 description-value
 

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -5,6 +5,7 @@ import {
   Snapshot,
   Trigger,
 } from './definitions';
+import { get_display_line } from './utils/get-display-line';
 import { get_trigger_body_line } from './utils/get-trigger-line';
 import { indent } from './utils/indent';
 
@@ -111,7 +112,11 @@ export class Runtime {
     const indented_expression = indent(body.text, runtime_indent_spaces);
     const indented_value = indent(value, runtime_indent_spaces);
 
-    const line = kind === 'type' ? header.line : trigger.footer!.line;
+    const line = get_display_line(
+      kind === 'type'
+        ? get_trigger_body_line(header.line)
+        : trigger.footer!.line,
+    );
     const line_info = this._config.transpile
       ? `\n(${this._filename}:${line})\n`
       : '';


### PR DESCRIPTION
additionally, report from type tests now shows line number from body instead of header