### PR TITLE
fix(options): add `<cwd>` placeholder for `typescript` option to better describe its path

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,7 @@ There are several options
 - typescript
   - default: `typescript` (node resolution)
   - specify which path of typescript to use
+  - `<cwd>` available
 - compiler_options
   - default: `{}`
   - specify which *path of `tsconfig.json` (string)* or *compilerOptions (object)* to use

--- a/src/utils/normalize-config.ts
+++ b/src/utils/normalize-config.ts
@@ -1,6 +1,7 @@
 import { NormalizedConfig, RawConfig } from '../definitions';
 import { load_compiler_options } from './load-compiler-options';
 import { load_typescript } from './load-typescript';
+import { replace_cwd } from './replace-cwd';
 
 export const normalize_config = (
   raw_config: RawConfig = {},
@@ -15,7 +16,9 @@ export const normalize_config = (
     transpile = true,
   } = raw_config;
 
-  const { typescript, typescript_path } = load_typescript(typescript_id);
+  const { typescript, typescript_path } = load_typescript(
+    replace_cwd(typescript_id),
+  );
 
   // istanbul ignore next
   const {

--- a/src/utils/replace-cwd.ts
+++ b/src/utils/replace-cwd.ts
@@ -1,0 +1,1 @@
+export const replace_cwd = (str: string) => str.replace('<cwd>', process.cwd());


### PR DESCRIPTION
Fixes #85 