### PR TITLE
Switch toThrowError to toThrow for Jest 30

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,8 +110,8 @@ _Note:_ [`@ts-expect-error`](https://devblogs.microsoft.com/typescript/announcin
   - for type assertion
     - default: none
     - `:show`: `console.log(type)`
-    - `:pass`: `expect(() => type)`[`.not`](https://facebook.github.io/jest/docs/en/expect.html#not)[`.toThrowError()`](https://facebook.github.io/jest/docs/en/expect.html#tothrowerror)
-    - `:fail`: `expect(() => type)`[`.toThrowError()`](https://facebook.github.io/jest/docs/en/expect.html#tothrowerror)
+    - `:pass`: `expect(() => type)`[`.not`](https://facebook.github.io/jest/docs/en/expect.html#not)[`.toThrow()`](https://facebook.github.io/jest/docs/en/expect.html#tothrowerror)
+    - `:fail`: `expect(() => type)`[`.toThrow()`](https://facebook.github.io/jest/docs/en/expect.html#tothrowerror)
     - `:snap`:
       - snapshot inferred type or diagnostic message
       - `expect(type)`[`.toMatchSnapshot()`](https://facebook.github.io/jest/docs/en/expect.html#tomatchsnapshotoptionalstring)
@@ -123,8 +123,8 @@ _Note:_ [`@ts-expect-error`](https://devblogs.microsoft.com/typescript/announcin
   - for value assertion
     - default: none
     - `?`: `console.log(value)`
-    - `:error`: `expect(() => value)`[`.toThrowError()`](https://facebook.github.io/jest/docs/en/expect.html#tothrowerror)
-    - `:no-error`: `expect(() => value)`[`.not`](https://facebook.github.io/jest/docs/en/expect.html#not)[`.toThrowError()`](https://facebook.github.io/jest/docs/en/expect.html#tothrowerror)
+    - `:error`: `expect(() => value)`[`.toThrow()`](https://facebook.github.io/jest/docs/en/expect.html#tothrowerror)
+    - `:no-error`: `expect(() => value)`[`.not`](https://facebook.github.io/jest/docs/en/expect.html#not)[`.toThrow()`](https://facebook.github.io/jest/docs/en/expect.html#tothrowerror)
     - others: `expect(value)`[`.toEqual(expected)`](https://facebook.github.io/jest/docs/en/expect.html#toequalvalue)
 
 ### Patterns for Grouping

--- a/src/__snapshots__/transform.test.ts.snap
+++ b/src/__snapshots__/transform.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`should retain line number while transforming 1`] = `
 "<create_setup_expression>;// @dts-jest:pass
-describe(\\"Object.assign({\\\\n    a: 1,\\\\n  }, {\\\\n    b: 2,\\\\n  }, {\\\\n    c: 3,\\\\n  })\\", function () { test(\\"(type) should not throw error\\", function () { expect(function () { _dts_jest_runtime_.get_type_inference_or_throw_diagnostic(1) }).not.toThrowError() });test(\\"(value) should equal to 123\\", function () { expect(Object.assign({ a: 1, }, { b: 2, }, { c: 3, })).toEqual(123) }) })
+describe(\\"Object.assign({\\\\n    a: 1,\\\\n  }, {\\\\n    b: 2,\\\\n  }, {\\\\n    c: 3,\\\\n  })\\", function () { test(\\"(type) should not throw error\\", function () { expect(function () { _dts_jest_runtime_.get_type_inference_or_throw_diagnostic(1) }).not.toThrow() });test(\\"(value) should equal to 123\\", function () { expect(Object.assign({ a: 1, }, { b: 2, }, { c: 3, })).toEqual(123) }) })
 
 
 
@@ -11,7 +11,7 @@ describe(\\"Object.assign({\\\\n    a: 1,\\\\n  }, {\\\\n    b: 2,\\\\n  }, {\\\
  //=> 123
 
 // @dts-jest:pass
-describe(\\"Object.assign({\\\\n    a: 1,\\\\n  }, {\\\\n    b: 2,\\\\n  }, {\\\\n    c: 3,\\\\n  })\\", function () { test(\\"(type) should not throw error\\", function () { expect(function () { _dts_jest_runtime_.get_type_inference_or_throw_diagnostic(10) }).not.toThrowError() });test(\\"(value) should equal to { a: 1, b: 2, c: 3, }\\", function () { expect(Object.assign({ a: 1, }, { b: 2, }, { c: 3, })).toEqual({ a: 1, b: 2, c: 3, }) }) })
+describe(\\"Object.assign({\\\\n    a: 1,\\\\n  }, {\\\\n    b: 2,\\\\n  }, {\\\\n    c: 3,\\\\n  })\\", function () { test(\\"(type) should not throw error\\", function () { expect(function () { _dts_jest_runtime_.get_type_inference_or_throw_diagnostic(10) }).not.toThrow() });test(\\"(value) should equal to { a: 1, b: 2, c: 3, }\\", function () { expect(Object.assign({ a: 1, }, { b: 2, }, { c: 3, })).toEqual({ a: 1, b: 2, c: 3, }) }) })
 
 
 
@@ -97,15 +97,15 @@ describe(\\"Object.assign({\\\\n      a: 1,\\\\n    }, {\\\\n      b: 2,\\\\n   
 
 exports[`should transform correctly with { test_type: true, test_value: false } 1`] = `
 "<create_setup_expression>;
-describe(\\"Math.max(1)\\", function () { test(\\"(type) should not throw error\\", function () { expect(function () { _dts_jest_runtime_.get_type_inference_or_throw_diagnostic(1) }).not.toThrowError() }) })
+describe(\\"Math.max(1)\\", function () { test(\\"(type) should not throw error\\", function () { expect(function () { _dts_jest_runtime_.get_type_inference_or_throw_diagnostic(1) }).not.toThrow() }) })
 
 describe(\\"A\\", function () { 
 
 
-describe(\\"Math.max(2)\\", function () { test(\\"(type) should not throw error\\", function () { expect(function () { _dts_jest_runtime_.get_type_inference_or_throw_diagnostic(6) }).not.toThrowError() }) })
+describe(\\"Math.max(2)\\", function () { test(\\"(type) should not throw error\\", function () { expect(function () { _dts_jest_runtime_.get_type_inference_or_throw_diagnostic(6) }).not.toThrow() }) })
 
 
-describe(\\"Math.max(3)\\", function () { test(\\"(type) should not throw error\\", function () { expect(function () { _dts_jest_runtime_.get_type_inference_or_throw_diagnostic(9) }).not.toThrowError() }) })
+describe(\\"Math.max(3)\\", function () { test(\\"(type) should not throw error\\", function () { expect(function () { _dts_jest_runtime_.get_type_inference_or_throw_diagnostic(9) }).not.toThrow() }) })
 
  });describe(\\"B\\", function () { 
 
@@ -113,7 +113,7 @@ describe(\\"Math.max(3)\\", function () { test(\\"(type) should not throw error\
 describe(\\"Math.max(4)\\", function () { test(\\"(type) should show report\\", function () { console.log(_dts_jest_runtime_.get_type_report(14)) }) })
 
 
-describe(\\"Object.assign({\\\\n      a: 1,\\\\n    }, {\\\\n      b: 2,\\\\n    }, {\\\\n      c: 3,\\\\n    })\\", function () { test(\\"(type) should not throw error\\", function () { expect(function () { _dts_jest_runtime_.get_type_inference_or_throw_diagnostic(17) }).not.toThrowError() }) })
+describe(\\"Object.assign({\\\\n      a: 1,\\\\n    }, {\\\\n      b: 2,\\\\n    }, {\\\\n      c: 3,\\\\n    })\\", function () { test(\\"(type) should not throw error\\", function () { expect(function () { _dts_jest_runtime_.get_type_inference_or_throw_diagnostic(17) }).not.toThrow() }) })
 
 
 
@@ -131,15 +131,15 @@ describe(\\"Object.assign({\\\\n      a: 1,\\\\n    }, {\\\\n      b: 2,\\\\n   
 
 exports[`should transform correctly with { test_type: true, test_value: true } 1`] = `
 "<create_setup_expression>;// @dts-jest:pass
-describe(\\"Math.max(1)\\", function () { test(\\"(type) should not throw error\\", function () { expect(function () { _dts_jest_runtime_.get_type_inference_or_throw_diagnostic(1) }).not.toThrowError() });test(\\"(value) should equal to 1\\", function () { expect(Math.max(1)).toEqual(1) }) }) //=> 1
+describe(\\"Math.max(1)\\", function () { test(\\"(type) should not throw error\\", function () { expect(function () { _dts_jest_runtime_.get_type_inference_or_throw_diagnostic(1) }).not.toThrow() });test(\\"(value) should equal to 1\\", function () { expect(Math.max(1)).toEqual(1) }) }) //=> 1
 
 describe(\\"A\\", function () { // @dts-jest:group A
 
 // @dts-jest:pass
-describe(\\"Math.max(2)\\", function () { test(\\"(type) should not throw error\\", function () { expect(function () { _dts_jest_runtime_.get_type_inference_or_throw_diagnostic(6) }).not.toThrowError() });test(\\"(value) should equal to 2\\", function () { expect(Math.max(2)).toEqual(2) }) }) //=> 2
+describe(\\"Math.max(2)\\", function () { test(\\"(type) should not throw error\\", function () { expect(function () { _dts_jest_runtime_.get_type_inference_or_throw_diagnostic(6) }).not.toThrow() });test(\\"(value) should equal to 2\\", function () { expect(Math.max(2)).toEqual(2) }) }) //=> 2
 
 // @dts-jest:pass
-describe(\\"Math.max(3)\\", function () { test(\\"(type) should not throw error\\", function () { expect(function () { _dts_jest_runtime_.get_type_inference_or_throw_diagnostic(9) }).not.toThrowError() });test(\\"(value) should equal to 3\\", function () { expect(Math.max(3)).toEqual(3) }) }) //=> 3
+describe(\\"Math.max(3)\\", function () { test(\\"(type) should not throw error\\", function () { expect(function () { _dts_jest_runtime_.get_type_inference_or_throw_diagnostic(9) }).not.toThrow() });test(\\"(value) should equal to 3\\", function () { expect(Math.max(3)).toEqual(3) }) }) //=> 3
 
  });describe(\\"B\\", function () { // @dts-jest:group B
 
@@ -147,7 +147,7 @@ describe(\\"Math.max(3)\\", function () { test(\\"(type) should not throw error\
 describe(\\"Math.max(4)\\", function () { test(\\"(type) should show report\\", function () { console.log(_dts_jest_runtime_.get_type_report(14)) });test(\\"(value) should show report\\", function () { console.log(_dts_jest_runtime_.get_value_report(14, function () { return Math.max(4) })) }) }) //=> ?
 
 // @dts-jest:pass
-describe(\\"Object.assign({\\\\n      a: 1,\\\\n    }, {\\\\n      b: 2,\\\\n    }, {\\\\n      c: 3,\\\\n    })\\", function () { test(\\"(type) should not throw error\\", function () { expect(function () { _dts_jest_runtime_.get_type_inference_or_throw_diagnostic(17) }).not.toThrowError() });test(\\"(value) should equal to { a: 1, b: 2, c: 3, }\\", function () { expect(Object.assign({ a: 1, }, { b: 2, }, { c: 3, })).toEqual({ a: 1, b: 2, c: 3, }) }) })
+describe(\\"Object.assign({\\\\n      a: 1,\\\\n    }, {\\\\n      b: 2,\\\\n    }, {\\\\n      c: 3,\\\\n    })\\", function () { test(\\"(type) should not throw error\\", function () { expect(function () { _dts_jest_runtime_.get_type_inference_or_throw_diagnostic(17) }).not.toThrow() });test(\\"(value) should equal to { a: 1, b: 2, c: 3, }\\", function () { expect(Object.assign({ a: 1, }, { b: 2, }, { c: 3, })).toEqual({ a: 1, b: 2, c: 3, }) }) })
 
 
 
@@ -174,22 +174,22 @@ describe(\\"path.basename('path/to/somewhere')\\", function () { test(\\"(value)
 
 exports[`should transform to fake environment for no-footers even if test_value = true 1`] = `
 "<create_setup_expression>;
-describe(\\"Math.max(1)\\", function () { test(\\"(type) should not throw error\\", function () { expect(function () { _dts_jest_runtime_.get_type_inference_or_throw_diagnostic(1) }).not.toThrowError() }) })
+describe(\\"Math.max(1)\\", function () { test(\\"(type) should not throw error\\", function () { expect(function () { _dts_jest_runtime_.get_type_inference_or_throw_diagnostic(1) }).not.toThrow() }) })
 
 describe(\\"A\\", function () { 
 
 
-describe(\\"Math.max(2)\\", function () { test(\\"(type) should not throw error\\", function () { expect(function () { _dts_jest_runtime_.get_type_inference_or_throw_diagnostic(6) }).not.toThrowError() }) })
+describe(\\"Math.max(2)\\", function () { test(\\"(type) should not throw error\\", function () { expect(function () { _dts_jest_runtime_.get_type_inference_or_throw_diagnostic(6) }).not.toThrow() }) })
 
 
-describe(\\"Math.max(3)\\", function () { test(\\"(type) should not throw error\\", function () { expect(function () { _dts_jest_runtime_.get_type_inference_or_throw_diagnostic(9) }).not.toThrowError() }) })
+describe(\\"Math.max(3)\\", function () { test(\\"(type) should not throw error\\", function () { expect(function () { _dts_jest_runtime_.get_type_inference_or_throw_diagnostic(9) }).not.toThrow() }) })
 
  });describe(\\"B\\", function () { 
 
 
-describe(\\"Math.max(4)\\", function () { test(\\"(type) should not throw error\\", function () { expect(function () { _dts_jest_runtime_.get_type_inference_or_throw_diagnostic(14) }).not.toThrowError() }) })
+describe(\\"Math.max(4)\\", function () { test(\\"(type) should not throw error\\", function () { expect(function () { _dts_jest_runtime_.get_type_inference_or_throw_diagnostic(14) }).not.toThrow() }) })
 
 
-describe(\\"Object.assign({ a: 1 }, { b: 2 }, { c: 3 })\\", function () { test(\\"(type) should not throw error\\", function () { expect(function () { _dts_jest_runtime_.get_type_inference_or_throw_diagnostic(17) }).not.toThrowError() }) })
+describe(\\"Object.assign({ a: 1 }, { b: 2 }, { c: 3 })\\", function () { test(\\"(type) should not throw error\\", function () { expect(function () { _dts_jest_runtime_.get_type_inference_or_throw_diagnostic(17) }).not.toThrow() }) })
  });"
 `;

--- a/src/remap-cli.test.ts
+++ b/src/remap-cli.test.ts
@@ -93,7 +93,7 @@ it('should throw error with differences if differences exist with --check and --
 });
 
 it('should throw error if there is no input', () => {
-  expect(() => remap_cli(remap_cli_parser([]))).toThrowError();
+  expect(() => remap_cli(remap_cli_parser([]))).toThrow();
   expect(get_console_content(console_error)).toMatchSnapshot();
 });
 

--- a/src/utils/__snapshots__/create-assertion-expression.test.ts.snap
+++ b/src/utils/__snapshots__/create-assertion-expression.test.ts.snap
@@ -6,7 +6,7 @@ Array [
     "Math.max(1, 2, 3)",
     Array [
       "test(\\"(type) should show report\\", function () { console.log(<get_type_report_expression>) })",
-      "test(\\"(type) should not throw error\\", function () { expect(function () { <get_type_inference_or_throw_diagnostic_expression> }).not.toThrowError() })",
+      "test(\\"(type) should not throw error\\", function () { expect(function () { <get_type_inference_or_throw_diagnostic_expression> }).not.toThrow() })",
       "test(\\"(type) should match snapshot\\", function () { expect(<get_type_inference_or_diagnostic_expression>).toMatchSnapshot() })",
       "test(\\"(value) should equal to 3\\", function () { expect(Math.max(1, 2, 3)).toEqual(3) })",
     ],
@@ -14,27 +14,27 @@ Array [
   Array [
     "Math.abs(-1)",
     Array [
-      "test(\\"(type) should throw error\\", function () { expect(function () { <get_type_inference_or_throw_diagnostic_expression> }).toThrowError() })",
+      "test(\\"(type) should throw error\\", function () { expect(function () { <get_type_inference_or_throw_diagnostic_expression> }).toThrow() })",
       "test(\\"(value) should show report\\", function () { console.log(<get_value_report_expression>) })",
     ],
   ],
   Array [
     "Math.cos(Math.PI)",
     Array [
-      "test(\\"(value) should not throw error\\", function () { expect(function () { Math.cos(Math.PI) }).not.toThrowError() })",
+      "test(\\"(value) should not throw error\\", function () { expect(function () { Math.cos(Math.PI) }).not.toThrow() })",
     ],
   ],
   Array [
     "Math.tan(Math.PI)",
     Array [
-      "test(\\"(value) should throw error\\", function () { expect(function () { Math.tan(Math.PI) }).toThrowError() })",
+      "test(\\"(value) should throw error\\", function () { expect(function () { Math.tan(Math.PI) }).toThrow() })",
     ],
   ],
   Array [
     "Math.sin(Math.PI)",
     Array [
       "test(\\"(type) should show report\\", function () { console.log(<get_type_report_expression>) })",
-      "test(\\"(type) should not throw error\\", function () { expect(function () { <get_type_inference_or_throw_diagnostic_expression> }).not.toThrowError() })",
+      "test(\\"(type) should not throw error\\", function () { expect(function () { <get_type_inference_or_throw_diagnostic_expression> }).not.toThrow() })",
       "test(\\"(type) should match snapshot\\", function () { expect(<get_type_inference_or_diagnostic_expression>).toMatchSnapshot() })",
       "test(\\"(value) should show report\\", function () { console.log(<get_value_report_expression>) })",
     ],

--- a/src/utils/create-assertion-expression.ts
+++ b/src/utils/create-assertion-expression.ts
@@ -47,7 +47,7 @@ export const create_assertion_expression = (
       expressions.push(
         create_wrapper(
           '(type) should not throw error',
-          `expect(function () { ${options.get_type_inference_or_throw_diagnostic_expression} }).not.toThrowError()`,
+          `expect(function () { ${options.get_type_inference_or_throw_diagnostic_expression} }).not.toThrow()`,
         ),
       );
     }
@@ -58,7 +58,7 @@ export const create_assertion_expression = (
       expressions.push(
         create_wrapper(
           '(type) should throw error',
-          `expect(function () { ${options.get_type_inference_or_throw_diagnostic_expression} }).toThrowError()`,
+          `expect(function () { ${options.get_type_inference_or_throw_diagnostic_expression} }).toThrow()`,
         ),
       );
     }
@@ -110,7 +110,7 @@ export const create_assertion_expression = (
       expressions.push(
         create_wrapper(
           '(value) should throw error',
-          `expect(function () { ${body.experssion} }).toThrowError()`,
+          `expect(function () { ${body.experssion} }).toThrow()`,
         ),
       );
     }
@@ -125,7 +125,7 @@ export const create_assertion_expression = (
       expressions.push(
         create_wrapper(
           '(value) should not throw error',
-          `expect(function () { ${body.experssion} }).not.toThrowError()`,
+          `expect(function () { ${body.experssion} }).not.toThrow()`,
         ),
       );
     }


### PR DESCRIPTION
Aliases were dropped in this PR:

- https://github.com/jestjs/jest/pull/14632

This is not a breaking change because the `.toThrowError()` matcher is just an alias of `.toThrow()` - so it should not fail with existing Jest versions:

https://jestjs.io/docs/expect#tothrowerror